### PR TITLE
Ignore Empty Streams & Fix Mutated Field Values

### DIFF
--- a/src/scripts/directives/device-action.js
+++ b/src/scripts/directives/device-action.js
@@ -44,7 +44,7 @@ angular.module('zetta').directive('zettaDeviceAction', [function() {
         scope.action.renderOptionsAsButton = true;
       }
 
-      scope.action.inputFields = scope.action.fields; // create copy so mutations dont show up in api response section
+      scope.action.inputFields = getFieldsCopy(scope.action); // create copy so mutations dont show up in api response section
       scope.action.inputFields.forEach(function(field, i) {
         if (!field.type) {
           field.type = 'text';
@@ -63,6 +63,16 @@ angular.module('zetta').directive('zettaDeviceAction', [function() {
         }
       });
     }
+
+    function getFieldsCopy(action) {
+      return action.fields.map(function(field){
+          var result = {};
+          for(var p in field) {
+              result[p] = field[p];
+          }
+          return result;
+        });
+    };
 
     scope.execute = function() {
       var button = $('.' + scope.action.name + '-button', element);

--- a/src/scripts/directives/linegraph.js
+++ b/src/scripts/directives/linegraph.js
@@ -1,16 +1,19 @@
 angular.module('zetta').directive('linegraph', ['$compile', function($compile) {
   function link(scope, element, attrs) {
     scope.$watchCollection('stream', function() {
-      
+
+      // Nothing in the stream; do nothing
+      if(!scope.stream || scope.stream.length == 0) return;
+
       function roundMS(ms){
         if(ms < 1000){ms = parseInt(ms);}
         return ms;
       }
-      
+
       stream = scope.stream.map(function(item){
         return {'x': parseInt(item[0].getTime()), 'y': item[1]};
-      }); 
-      
+      });
+
       var x = d3.time.scale().range([0, element.parent()[0].clientWidth - 6]);
       var y = d3.scale.linear().range([74, 0]);
 
@@ -20,9 +23,9 @@ angular.module('zetta').directive('linegraph', ['$compile', function($compile) {
       scope.line = d3.svg.line()
           .x(function(d) {return x(d.x) - 6;})
           .y(function(d) {return y(d.y)+3;});
-      
+
       var total = stream[stream.length -1].x - stream[0].x;
-      
+
       scope.label = {
         q1: "0",
         q2: roundMS(total * .25),
@@ -31,37 +34,39 @@ angular.module('zetta').directive('linegraph', ['$compile', function($compile) {
         q5: total,
         min: 0,
         max: 0
-      }
-      
+      };
+
       var d = scope.line(stream);
 
-      
+
       var mm = {
         raw: d3.extent(stream.map(function(point){return point.y})),
         min: null,
         max: null,
         val: stream[stream.length-1]
       }
-      
+
       stream.forEach(function(point){
+
         if(mm.min == null && point.y == mm.raw[0]){
           mm.min = point;
           scope.label.min = point.y
         }
-        else if(mm.max == null && point.y == mm.raw[1]){
-           mm.max = point;
-           scope.label.max = point.y
+
+        if(mm.max == null && point.y == mm.raw[1]){
+          mm.max = point;
+          scope.label.max = point.y
         }
       });
-      
+
       //console.log(x(mm.max.x));
-      
+
       if (d) {
-        
+
        angular.element(element[0].querySelector('.dataline')).attr({"d": d});
        angular.element(element[0].querySelector('.min')).attr({
         "cx": x(mm.min.x)-6,
-        "cy": y(mm.min.y) 
+        "cy": y(mm.min.y)
        });
        angular.element(element[0].querySelector('.max')).attr({
         "cx": x(mm.max.x)-6,
@@ -71,10 +76,10 @@ angular.module('zetta').directive('linegraph', ['$compile', function($compile) {
         "cx": x(mm.val.x)-4,
         "cy": y(mm.val.y) + 3
        });
-        
+
       }
-      
-    }); 
+
+    });
   }
 
   return {

--- a/src/scripts/directives/overview-action.js
+++ b/src/scripts/directives/overview-action.js
@@ -1,6 +1,6 @@
 angular.module('zetta').directive('zettaOverviewAction', [function() {
   var link = function(scope, element) {
-    
+
     function isRadioButtons(action) {
         scope.device.name = scope.device.name ?  scope.device.name : scope.device.type
         console.log('devProps', scope.device.name);
@@ -45,7 +45,7 @@ angular.module('zetta').directive('zettaOverviewAction', [function() {
         scope.action.renderOptionsAsButton = true;
       }
 
-      scope.action.inputFields = scope.action.fields; // create copy so mutations dont show up in api response section
+      scope.action.inputFields = getFieldsCopy(scope.action); // create copy so mutations dont show up in api response section
       scope.action.inputFields.forEach(function(field, i) {
         if (!field.type) {
           field.type = 'text';
@@ -64,6 +64,16 @@ angular.module('zetta').directive('zettaOverviewAction', [function() {
         }
       });
     }
+
+    function getFieldsCopy(action) {
+      return action.fields.map(function(field){
+          var result = {};
+          for(var p in field) {
+              result[p] = field[p];
+          }
+          return result;
+        });
+    };
 
     scope.execute = function() {
       var button = $('.' + scope.action.name + '-button', element);

--- a/src/scripts/directives/sparkline.js
+++ b/src/scripts/directives/sparkline.js
@@ -1,10 +1,14 @@
 angular.module('zetta').directive('sparkline', ['$compile', function($compile) {
   function link(scope, element, attrs) {
     scope.$watchCollection('stream', function() {
+
+      // Nothing in the stream; do nothing
+      if(!scope.stream || scope.stream.length == 0) return;
+      
       stream = scope.stream.map(function(item){
         return {'x': parseInt(item[0].getTime()), 'y': item[1]};
-      }); 
-      
+      });
+
       var x = d3.time.scale().range([0, element.parent()[0].clientWidth]);
       var y = d3.scale.linear().range([scope.height-6, 0]);
 
@@ -16,10 +20,10 @@ angular.module('zetta').directive('sparkline', ['$compile', function($compile) {
           .y(function(d) {return y(d.y) + 3;});
 
       var d = scope.line(stream);
-      
+
       if (d) { element.find('path').attr({"d": d}); }
-      
-    }); 
+
+    });
   }
 
   return {

--- a/src/scripts/siren/module.js
+++ b/src/scripts/siren/module.js
@@ -12,7 +12,7 @@ angular
         map[c] = { known: true, state: state };
         return this;
       };
-      
+
       this.otherwise = function(state) {
         map[null] = { known: false, state: state };
       };
@@ -64,14 +64,14 @@ angular
           if (!immediateReturn || (redirectIfKnown && state.known)) {
             self.cache.push(self.current);
           }
-          
+
           $rootScope.$broadcast('entityChangeSuccess', data);
 
           $state.transitionTo(state.state, params);
 
           var stateIsUnknown = !state.known;
           var resolveIfKnown = !redirectIfKnown;
-          
+
           if (immediateReturn && (stateIsUnknown || resolveIfKnown)) {
             deferred.resolve(data);
           }
@@ -98,7 +98,7 @@ angular
         if (options.method === 'GET') {
           var params = {};
 
-          angular.forEach(action.fields, function(field) {
+          angular.forEach(action.inputFields, function(field) {
           console.log(field);
             params[field.name] = field.value;
           });
@@ -112,7 +112,7 @@ angular
             return str.join("&");
           };
 
-          options.url = options.url.split('?')[0] + '?' + serialize(params); 
+          options.url = options.url.split('?')[0] + '?' + serialize(params);
 
           //$state.transitionTo('entity', { url: url });
 
@@ -130,12 +130,12 @@ angular
         } else {
           if (contentType === 'application/json') {
             options.data = {};
-            angular.forEach(action.fields, function(field) {
+            angular.forEach(action.inputFields, function(field) {
               options.data[field.name] = field.value;
             });
           } else if (contentType === 'application/x-www-form-urlencoded') {
             var data = [];
-            angular.forEach(action.fields, function(field) {
+            angular.forEach(action.inputFields, function(field) {
               data.push(encodeURIComponent(field.name) + '=' + encodeURIComponent(field.value));
             });
 


### PR DESCRIPTION
Updated the 'linegraph' and 'sparkline' directives to ignore empty
stream data updates. Otherwise the 'stream' array set by map is
empty and later attempts to access expected values within the
array throws exceptions. Also, the 'linegraph' setting of min and
max point instances contained an if/else where I believe it was
meant to be two separate if statements.

Updated overview-action and device-action to create true copies of
the action 'inputFields' array. Setting one array equal to another
does creates a reference and later updates DO cause mutations.
Those unexpected changes result in errors when moving between the
overview-action and device-action views. One example is on later
calls to 'isRadioButtons', where 'radio.value' is a string and
no longer an array.

Updated 'execute' method of siren/module to send the field values
found at 'action.inputFields' instead 'action.fields'. The use of
'action.fields' only worked because true copies were not created
(see above). The 'inputFields' array is the copy and contains the
expected data values.