### PR TITLE
add support for oauth tokens

### DIFF
--- a/src/partials/start.html
+++ b/src/partials/start.html
@@ -7,28 +7,25 @@
         {{errMsg}}
       </div>
       <form class="pure-form">
-        <fieldset class="pure-group">
-        <input placeholder="Server URL" type="url" ng-model="params.url" name="url" class="pure-u-1 pure-u-md-1-2"/>
-        <button ng-click="fetchUrl(params)" class="pure-button">Connect</button>
+        <fieldset>
+          <input placeholder="Server URL" type="url" ng-model="params.url" name="url" class="pure-u-1 pure-u-md-1-2"/>
+          <button ng-click="fetchUrl(params)" class="pure-button">Connect</button>
+
+          <div class="pure-u-md-1-3" style="margin-top: -15px; padding-left: 10px;">
+          <h3 >Select Security scheme</h3>
+          <label for="option-no-sec" style="padding-right: 10px;">
+            <input id="option-no-sec" type="radio" ng-model="params.security" name="optionsRadios" value="none" checked>
+            None
+          </label>
+          <label for="option-oauth">
+              <input id="option-oauth" type="radio" ng-model="params.security" name="optionsRadios" value="oauth">
+              OAuth
+          </label>
+          </div>
         </fieldset>
-       
-        <p>Select Security scheme</p>
-        
-        <label for="option-no-sec" class="pure-radio">
-          <input id="option-no-sec" type="radio" ng-model="params.security" name="optionsRadios" value="none" checked>
-          None
-        </label>
-
-      <label for="option-oauth" class="pure-radio">
-          <input id="option-oauth" type="radio" ng-model="params.security" name="optionsRadios" value="oauth">
-          OAuth
-      </label>
-    
-        <input placeholder="OAuthToken" type="text" ng-disabled="params.security!='oauth'" ng-model="params.oauthtoken" name="oauthtoken" class="pure-u-1 pure-u-md-1-2"/>
-          
+        <h4 ng-hide="params.security!='oauth'">OAuth Token</h4>
+        <input placeholder="OAuthToken" type="text" ng-hide="params.security!='oauth'" ng-disabled="params.security!='oauth'" ng-model="params.oauthtoken" name="oauthtoken" class="pure-u-1 pure-u-md-1-2"/>
       </form>
-    
-
     </section>
   </header>
   <section class="device-meta pure-u-1" ng-show="serverUrls.length">

--- a/src/partials/start.html
+++ b/src/partials/start.html
@@ -7,9 +7,28 @@
         {{errMsg}}
       </div>
       <form class="pure-form">
+        <fieldset class="pure-group">
         <input placeholder="Server URL" type="url" ng-model="params.url" name="url" class="pure-u-1 pure-u-md-1-2"/>
         <button ng-click="fetchUrl(params)" class="pure-button">Connect</button>
+        </fieldset>
+       
+        <p>Select Security scheme</p>
+        
+        <label for="option-no-sec" class="pure-radio">
+          <input id="option-no-sec" type="radio" ng-model="params.security" name="optionsRadios" value="none" checked>
+          None
+        </label>
+
+      <label for="option-oauth" class="pure-radio">
+          <input id="option-oauth" type="radio" ng-model="params.security" name="optionsRadios" value="oauth">
+          OAuth
+      </label>
+    
+        <input placeholder="OAuthToken" type="text" ng-disabled="params.security!='oauth'" ng-model="params.oauthtoken" name="oauthtoken" class="pure-u-1 pure-u-md-1-2"/>
+          
       </form>
+    
+
     </section>
   </header>
   <section class="device-meta pure-u-1" ng-show="serverUrls.length">

--- a/src/scripts/controllers/device.js
+++ b/src/scripts/controllers/device.js
@@ -72,8 +72,11 @@ angular.module('zetta').controller('DeviceCtrl', [
 
       $scope.loggerUrl = url;
     }
-
-    $scope.loggerSocket = new WebSocket($scope.loggerUrl);
+    //add token as query param query param for WS connections 
+    var _turl = $scope.loggerUrl;
+    if(zettaShared.state.oauthtoken && zettaShared.state.oauthtoken!='')
+      _turl += (_turl.split('?')[1] ? '&':'?') + 'token=' + zettaShared.state.oauthtoken;
+    $scope.loggerSocket = new WebSocket(_turl);
     
     $scope.loggerSocket.onmessage = function(event) {
       var d = JSON.parse(event.data);

--- a/src/scripts/controllers/main.js
+++ b/src/scripts/controllers/main.js
@@ -1,6 +1,6 @@
 angular.module('zetta').controller('MainCtrl', [
-  '$scope', '$state', 'navigator', 'appState', 'zettaShared',
-  function($scope, $state, navigator, appState, zettaShared) {
+  '$scope', '$state', 'navigator', 'appState', 'zettaShared', '$http',
+  function($scope, $state, navigator, appState, zettaShared, $http) {
     zettaShared.state.breadcrumbs = [];
     zettaShared.state.servers = [];
     zettaShared.state.pinned = [];
@@ -8,11 +8,18 @@ angular.module('zetta').controller('MainCtrl', [
 
     $scope.init = function() {
       $scope.params = { url: appState.url || '' };
+      $scope.params.security='none'
     };
 
     $scope.errMsg = null;
     
     $scope.fetchUrl = function(params) {
+      if(params.oauthtoken && params.oauthtoken!='')
+      {
+        $http.defaults.headers.common.Authorization = 'Bearer ' + params.oauthtoken
+        zettaShared.state.oauthtoken = params.oauthtoken
+      }
+
       $scope.errMsg = null;
       if (!params.url) {
         return;

--- a/src/scripts/services/zetta-shared.js
+++ b/src/scripts/services/zetta-shared.js
@@ -111,11 +111,14 @@ angular.module('zetta').factory('zettaShared', ['$http', '$state', 'navigator', 
       if (objectStream.title === 'logs') {
         device.monitorHref = objectStream.href;
       } else {
+        var _turl = objectStream.href;
+        if(state.oauthtoken && state.oauthtoken!='')
+          _turl += (_turl.split('?')[1] ? '&':'?') + 'token=' + state.oauthtoken;
         var stream = {
           id: device.server.name.replace(/\./g, '-') + 'device' + device.server.devices.length + 'stream' + state.savedStreams.length + objectStream.title,
           name: objectStream.title,
           href: objectStream.href,
-          socket: new WebSocket(objectStream.href),
+          socket: new WebSocket(_turl),
           device: device,
           data: [],
           pinned: false,
@@ -133,7 +136,12 @@ angular.module('zetta').factory('zettaShared', ['$http', '$state', 'navigator', 
 
         stream.socket.onclose = function() {
           var oldOnMessage = stream.socket.onmessage;
-          stream.socket = new WebSocket(stream.href);
+
+          var _turl = stream.href;
+          if(state.oauthtoken && state.oauthtoken!='')
+            _turl += (_turl.split('?')[1] ? '&':'?') + 'token=' + state.oauthtoken;
+          stream.socket = new WebSocket(_turl);
+
           stream.socket.onmessage = oldOnMessage;
         };
 
@@ -176,7 +184,7 @@ angular.module('zetta').factory('zettaShared', ['$http', '$state', 'navigator', 
     $http.get(rootUrl).then(function(response) {
       var data = response.data;
       if (typeof data === 'string') {
-        data = JSON.parse(data);
+        data = JSON.parseInte(data);
       }
 
       var serverLinks = data.links.filter(function(link) {
@@ -208,7 +216,11 @@ angular.module('zetta').factory('zettaShared', ['$http', '$state', 'navigator', 
         data.links.forEach(function(link) {
           if (link.rel.indexOf('monitor') !== -1) {
             server.monitorHref = link.href;
-            server.monitorSocket = new WebSocket(link.href);
+            
+            var _turl = link.href;
+            if(state.oauthtoken&&state.oauthtoken!='')
+              _turl += (_turl.split('?')[1] ? '&':'?') + 'token=' + state.oauthtoken;
+            server.monitorSocket = new WebSocket(_turl);
           }
         });
         
@@ -329,6 +341,7 @@ angular.module('zetta').factory('zettaShared', ['$http', '$state', 'navigator', 
       }
     
       var data = result.data;
+      console.log(data)
       var device = state.buildDeviceFromData(data);
 
       if (device.server) {


### PR DESCRIPTION
adds UI support for specifying oauth access tokens in the browser, if the APIs are secured by oauth
<img width="712" alt="screen shot 2016-01-20 at 10 16 27 pm" src="https://cloud.githubusercontent.com/assets/1277515/12473062/7e5a97ac-bfc3-11e5-80a6-c71e3208e636.png">

when specified,
> adds 'Authorization: Bearer <access_token>' to header for all http/https requests
> adds a query param 'token=<access_token>' for all ws requests

why?
for real world use, the zetta cloud APIs needs to be secured - usually with oauth. this is usually achieved by adding a security layer, provided by an api gateway or api management, on top of zetta cloud APIs
so this option, will let developers browse the APIs when they are secured 

